### PR TITLE
Fix/doctrine

### DIFF
--- a/src/Api/Adapter/ItemSetsTreeEdgeAdapter.php
+++ b/src/Api/Adapter/ItemSetsTreeEdgeAdapter.php
@@ -48,12 +48,21 @@ class ItemSetsTreeEdgeAdapter extends AbstractEntityAdapter
 
     public function hydrate(Request $request, EntityInterface $entity, ErrorStore $errorStore)
     {
+        // Refresh the reference to avoid issues with doctrine.
         if ($this->shouldHydrate($request, 'o:item_set')) {
-            $entity->setItemSet($request->getValue('o:item_set'));
+            $itemSet = $request->getValue('o:item_set');
+            $itemSet = $itemSet
+                ? $this->getEntityManager()->getReference(\Omeka\Entity\ItemSet::class, $itemSet->getId())
+                : null;
+            $entity->setItemSet($itemSet);
         }
 
         if ($this->shouldHydrate($request, 'o:parent_item_set')) {
-            $entity->setParentItemSet($request->getValue('o:parent_item_set'));
+            $itemSet = $request->getValue('o:parent_item_set');
+            $itemSet = $itemSet
+                ? $this->getEntityManager()->getReference(\Omeka\Entity\ItemSet::class, $itemSet->getId())
+                : null;
+            $entity->setParentItemSet($itemSet);
         }
     }
 

--- a/src/Site/BlockLayout/ItemSetsTree.php
+++ b/src/Site/BlockLayout/ItemSetsTree.php
@@ -31,7 +31,7 @@ class ItemSetsTree extends AbstractBlockLayout
             'linkEmpty' => true,
         ];
 
-        $data = $block ? $block->data() + $defaults : $defaults;
+        $data = $block ? ($block->data() ?? []) + $defaults : $defaults;
 
         $form = new Form();
         $form->add([


### PR DESCRIPTION
Bonjour,
Rafraichir les collections liées lors de l'hydratation évite des problèmes doctrines. Il y a sans doute un incompatibilité avec autre module, mais cette solution résout les problèmes.